### PR TITLE
Remove styles that smushed the button

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,8 +22,8 @@ const Home: NextPage = () => {
         </p>
 
 
-        <div className="flex items-center">
-          <TextField label="Email address" variant="outlined" margin="normal" className="mr-4 flex-grow"/>
+        <div className="flex my-4">
+          <TextField label="Email address" variant="outlined" margin="none" className="mr-4 flex-grow"/>
           <Button variant="contained" className="flex w-40">Start now</Button>
         </div>
       </main>


### PR DESCRIPTION
The alignment for the center buttons was thrown off because the div wrapping it had items-central as an attached style.