### PR TITLE
Use locale context instead of prop drilling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# scratch files
+scratch.*

--- a/components/atoms/LocalizedLink.tsx
+++ b/components/atoms/LocalizedLink.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import Link from 'next/link';
 import { SupportedLocale } from '../../@types';
 import { pathFromComponents } from '../../utils/linking';
-import { LocaleContext } from '../molecules/TranslationsWrapper';
+import { TranslationContext } from '../page_wrappers/TranslationsWrapper';
 
 type Props = {
   path: string
@@ -11,7 +11,7 @@ type Props = {
 };
 
 export const LocalizedLink = ({ path, children, newLocale }: Props) => {
-  const { locale: currentLocale } = useContext(LocaleContext);
+  const { locale: currentLocale } = useContext(TranslationContext);
   return (
     <Link href={ pathFromComponents(currentLocale, path, newLocale) }>
       { children }

--- a/components/atoms/LocalizedLink.tsx
+++ b/components/atoms/LocalizedLink.tsx
@@ -1,16 +1,17 @@
-import React from "react";
+import React, { useContext } from 'react';
 import Link from 'next/link';
-import { SupportedLocale } from "../../@types";
-import { pathFromComponents } from "../../utils/linking";
+import { SupportedLocale } from '../../@types';
+import { pathFromComponents } from '../../utils/linking';
+import { LocaleContext } from '../molecules/TranslationsWrapper';
 
 type Props = {
-  currentLocale: SupportedLocale
   path: string
   children: any
   newLocale?: SupportedLocale
 };
 
-export const LocalizedLink = ({ currentLocale, path, children, newLocale }: Props) => {
+export const LocalizedLink = ({ path, children, newLocale }: Props) => {
+  const { locale: currentLocale } = useContext(LocaleContext);
   return (
     <Link href={ pathFromComponents(currentLocale, path, newLocale) }>
       { children }

--- a/components/compounds/Header.tsx
+++ b/components/compounds/Header.tsx
@@ -10,7 +10,7 @@ import { LocaleContext } from '../molecules/TranslationsWrapper';
 
 const Menu = React.memo(() => {
   const router = useRouter();
-  const locale = useContext(LocaleContext).locale;
+  const { locale } = useContext(LocaleContext);
   // consider extracting to generic routing function
   const handleButtonPress = (path: string) => {
     router.push(pathFromComponents(locale, path));

--- a/components/compounds/Header.tsx
+++ b/components/compounds/Header.tsx
@@ -1,19 +1,16 @@
 import { Button, Divider, Typography } from '@mui/material';
-import React from 'react';
+import React, { useContext } from 'react';
 import { useRouter } from 'next/router';
 import { DrawerMenuItem } from '../molecules/DrawerMenuItem';
 import { DrawerMenu } from './DrawerMenu';
 import { AddBoxOutlined, ExitToAppOutlined, LocalOfferOutlined, MailOutlined } from '@mui/icons-material';
 import { LanguagePicker } from '../molecules/LanguagePicker';
-import { SupportedLocale } from '../../@types';
 import { pathFromComponents } from '../../utils/linking';
+import { LocaleContext } from '../molecules/TranslationsWrapper';
 
-type MenuProps = {
-  locale: SupportedLocale
-};
-const Menu = React.memo<MenuProps>(({ locale }) => {
+const Menu = React.memo(() => {
   const router = useRouter();
-
+  const locale = useContext(LocaleContext).locale;
   // consider extracting to generic routing function
   const handleButtonPress = (path: string) => {
     router.push(pathFromComponents(locale, path));
@@ -22,7 +19,7 @@ const Menu = React.memo<MenuProps>(({ locale }) => {
   return (
     <>
       <div className="hidden md:flex flex-row justify-between w-128">
-        <LanguagePicker locale={ locale }/>
+        <LanguagePicker />
         <Button variant="text" color="secondary" onClick={ () => handleButtonPress('/login') }>
           Pricing
         </Button>
@@ -34,14 +31,14 @@ const Menu = React.memo<MenuProps>(({ locale }) => {
         </Button>
       </div>
       <div className="md:hidden flex flex-grow justify-end mr-4" >
-        <LanguagePicker locale={ locale }/>
+        <LanguagePicker/>
       </div>
       <DrawerMenu className="md:hidden">
-        <DrawerMenuItem icon={ <LocalOfferOutlined /> } label="Pricing" locale={ locale } path='/'/>
-        <DrawerMenuItem icon={ <MailOutlined /> } label="Contact us" locale={ locale } path='/'/>
+        <DrawerMenuItem icon={ <LocalOfferOutlined /> } label="Pricing" path='/'/>
+        <DrawerMenuItem icon={ <MailOutlined /> } label="Contact us" path='/'/>
         <Divider variant="middle" />
-        <DrawerMenuItem icon={ <AddBoxOutlined /> } label="Sign up" locale={ locale } path='/'/>
-        <DrawerMenuItem icon={ <ExitToAppOutlined /> } label="Log in" locale={ locale } path='/login'/>
+        <DrawerMenuItem icon={ <AddBoxOutlined /> } label="Sign up" path='/'/>
+        <DrawerMenuItem icon={ <ExitToAppOutlined /> } label="Log in" path='/login'/>
       </DrawerMenu>
     </>
   );
@@ -50,16 +47,13 @@ const Menu = React.memo<MenuProps>(({ locale }) => {
 Menu.displayName = 'Menu';
 
 // TODO: If we end up having menus with different items, we should make that a prop
-type HeaderProps = {
-  locale: SupportedLocale
-};
-export const Header = ({ locale }: HeaderProps) => {
+export const Header = () => {
   return (
     <div className="flex flex-row justify-between items-center">
       <Typography variant="h3" component="h1">
         NPM
       </Typography>
-      <Menu locale={ locale }/>
+      <Menu/>
     </div>
   );
 };

--- a/components/compounds/Header.tsx
+++ b/components/compounds/Header.tsx
@@ -6,11 +6,11 @@ import { DrawerMenu } from './DrawerMenu';
 import { AddBoxOutlined, ExitToAppOutlined, LocalOfferOutlined, MailOutlined } from '@mui/icons-material';
 import { LanguagePicker } from '../molecules/LanguagePicker';
 import { pathFromComponents } from '../../utils/linking';
-import { LocaleContext } from '../molecules/TranslationsWrapper';
+import { TranslationContext } from '../page_wrappers/TranslationsWrapper';
 
 const Menu = React.memo(() => {
   const router = useRouter();
-  const { locale } = useContext(LocaleContext);
+  const { locale } = useContext(TranslationContext);
   // consider extracting to generic routing function
   const handleButtonPress = (path: string) => {
     router.push(pathFromComponents(locale, path));

--- a/components/molecules/DrawerMenuItem.tsx
+++ b/components/molecules/DrawerMenuItem.tsx
@@ -1,7 +1,6 @@
 import { ListItemIcon, ListItemText, MenuItem } from '@mui/material';
-import React, { useContext } from 'react';
+import React from 'react';
 import { LocalizedLink } from '../atoms/LocalizedLink';
-import { LocaleContext } from './TranslationsWrapper';
 
 type Props = {
   icon: React.ReactNode
@@ -10,9 +9,8 @@ type Props = {
 };
 
 export const DrawerMenuItem = ({ icon, label, path }: Props) => {
-  const locale = useContext(LocaleContext).locale;
   return (
-    <LocalizedLink currentLocale={ locale } path={ path }>
+    <LocalizedLink path={ path }>
       <MenuItem>
         <ListItemIcon>
           { icon }

--- a/components/molecules/DrawerMenuItem.tsx
+++ b/components/molecules/DrawerMenuItem.tsx
@@ -1,16 +1,16 @@
 import { ListItemIcon, ListItemText, MenuItem } from '@mui/material';
-import React from 'react';
-import { SupportedLocale } from '../../@types';
+import React, { useContext } from 'react';
 import { LocalizedLink } from '../atoms/LocalizedLink';
+import { LocaleContext } from './TranslationsWrapper';
 
 type Props = {
   icon: React.ReactNode
   label: string
-  locale: SupportedLocale
   path: string
 };
 
-export const DrawerMenuItem = ({ icon, label, locale, path }: Props) => {
+export const DrawerMenuItem = ({ icon, label, path }: Props) => {
+  const locale = useContext(LocaleContext).locale;
   return (
     <LocalizedLink currentLocale={ locale } path={ path }>
       <MenuItem>

--- a/components/molecules/LanguagePicker.tsx
+++ b/components/molecules/LanguagePicker.tsx
@@ -13,7 +13,7 @@ export const LanguagePicker = React.memo(() => {
   // if we are not en, our current path will have /locale/ at the front, which we should remove
   // if we have /ja, we can just remove ja
   // if we have /ja/page, we should remove the redundant slash
-  const locale = useContext(LocaleContext).locale;
+  const { locale } = useContext(LocaleContext);
   const pathWithNoLocale = locale === 'en' ? router.asPath : router.asPath.replace(`${locale}`, '').replace("//", "/");
   const handlePickerChange = (event: SelectChangeEvent<SupportedLocale>) => {
     const newLocale = event.target.value as SupportedLocale;

--- a/components/molecules/LanguagePicker.tsx
+++ b/components/molecules/LanguagePicker.tsx
@@ -5,7 +5,7 @@ import { SupportedLocale } from "../../@types";
 import { useRouter } from 'next/router';
 import { languageDefinitions } from "../../supportedLocales";
 import { pathFromComponents } from "../../utils/linking";
-import { LocaleContext } from "./TranslationsWrapper";
+import { TranslationContext } from "../page_wrappers/TranslationsWrapper";
 
 export const LanguagePicker = React.memo(() => {
   const router = useRouter();
@@ -13,7 +13,7 @@ export const LanguagePicker = React.memo(() => {
   // if we are not en, our current path will have /locale/ at the front, which we should remove
   // if we have /ja, we can just remove ja
   // if we have /ja/page, we should remove the redundant slash
-  const { locale } = useContext(LocaleContext);
+  const { locale } = useContext(TranslationContext);
   const pathWithNoLocale = locale === 'en' ? router.asPath : router.asPath.replace(`${locale}`, '').replace("//", "/");
   const handlePickerChange = (event: SelectChangeEvent<SupportedLocale>) => {
     const newLocale = event.target.value as SupportedLocale;

--- a/components/molecules/LanguagePicker.tsx
+++ b/components/molecules/LanguagePicker.tsx
@@ -1,17 +1,19 @@
 import { Language } from "@mui/icons-material";
 import { SelectChangeEvent, MenuItem, Typography, Select } from "@mui/material";
-import React, { useCallback } from "react";
+import React, { useCallback, useContext } from "react";
 import { SupportedLocale } from "../../@types";
 import { useRouter } from 'next/router';
 import { languageDefinitions } from "../../supportedLocales";
 import { pathFromComponents } from "../../utils/linking";
+import { LocaleContext } from "./TranslationsWrapper";
 
-export const LanguagePicker = React.memo<{ locale: SupportedLocale }>(({ locale }) => {
+export const LanguagePicker = React.memo(() => {
   const router = useRouter();
 
   // if we are not en, our current path will have /locale/ at the front, which we should remove
   // if we have /ja, we can just remove ja
   // if we have /ja/page, we should remove the redundant slash
+  const locale = useContext(LocaleContext).locale;
   const pathWithNoLocale = locale === 'en' ? router.asPath : router.asPath.replace(`${locale}`, '').replace("//", "/");
   const handlePickerChange = (event: SelectChangeEvent<SupportedLocale>) => {
     const newLocale = event.target.value as SupportedLocale;

--- a/components/molecules/TranslationsWrapper.tsx
+++ b/components/molecules/TranslationsWrapper.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { SupportedLocale } from '../../@types';
+
+type Props = {
+  locale: SupportedLocale
+  children: JSX.Element
+};
+
+export const LocaleContext = React.createContext<{ locale: SupportedLocale }>({ locale: 'en' });
+export const TranslationsWrapper = ({ locale, children }: Props) => {  
+  return (
+    <LocaleContext.Provider value={ { locale } } >
+      { children } 
+    </LocaleContext.Provider>
+  );
+};

--- a/components/page_wrappers/TranslationsWrapper.tsx
+++ b/components/page_wrappers/TranslationsWrapper.tsx
@@ -6,11 +6,11 @@ type Props = {
   children: JSX.Element
 };
 
-export const LocaleContext = React.createContext<{ locale: SupportedLocale }>({ locale: 'en' });
+export const TranslationContext = React.createContext<{ locale: SupportedLocale }>({ locale: 'en' });
 export const TranslationsWrapper = ({ locale, children }: Props) => {  
   return (
-    <LocaleContext.Provider value={ { locale } } >
+    <TranslationContext.Provider value={ { locale } } >
       { children } 
-    </LocaleContext.Provider>
+    </TranslationContext.Provider>
   );
 };

--- a/components/templates/HomeTemplate.tsx
+++ b/components/templates/HomeTemplate.tsx
@@ -8,78 +8,82 @@ import { assetUrls } from '../../utils/assetUrls';
 import { Section } from '../atoms/Section';
 import { Header } from '../compounds/Header';
 import { FeatureSection } from '../molecules/FeatureSection';
+import { TranslationsWrapper } from '../molecules/TranslationsWrapper';
 
 export const HomeTemplate: TopLevelTemplate = ({ locale }) => {
+
   return (
-    <div className="h-screen min-h-screen px-2 flex flex-col items-center">
-      <Head>
-        <title>NPM</title>
-        <meta name="description" content="Mushroom subscription service" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+    <TranslationsWrapper locale={ locale }>
+      <div className="h-screen min-h-screen px-2 flex flex-col items-center">
+        <Head>
+          <title>NPM</title>
+          <meta name="description" content="Mushroom subscription service" />
+          <link rel="icon" href="/favicon.ico" />
+        </Head>
 
-      <main className="flex flex-col justify-start">
+        <main className="flex flex-col justify-start">
+          <Section>
+            <Header/>
+
+            <Typography variant="h4" component="h2" className="py-20">
+              Premium { locale === 'en' ? 'mushrooms' : '椎茸' } at your doorstep, every month.
+            </Typography>
+
+            <div className="flex flex-col md:flex-row md:justify-center">
+              <TextField label="Email address" variant="outlined" className="flex-grow max-w-lg mb-4 md:mr-4 md:mb-0"/>
+              <Button variant="contained" className="flex w-40 self-center md:self-auto">Start now</Button>
+            </div>
+          </Section>
+          <Section backgroundColor="primary.background">
+            <FeatureSection
+              text="Organic, locally sourced, free-range mushrooms."
+              imageElement={
+                <Image
+                  src={ assetUrls.happyMushroom }
+                  alt="happy mushroom"
+                  width={ 200 }
+                  height={ 200 }
+                />
+              }
+            />
+          </Section>
+          <Section>
+            <FeatureSection
+              text="Our QA teams ensure that the mushrooms are not poisonous."
+              imageElement={
+                <iframe
+                  width="560"
+                  height="315"
+                  src={ assetUrls.qaTeam }
+                  frameBorder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                />
+              }
+              isImageOnLeft
+            />
+          </Section>
+          <Section backgroundColor="primary.background">
+            <FeatureSection
+              text="Loreming the ipsums. There should be 3 sections."
+              imageElement={
+                <Image
+                  src={ assetUrls.happyMushroom }
+                  alt="dancing mushroom"
+                  width={ 200 }
+                  height={ 200 }
+                />
+              }
+            />
+          </Section>
+        </main>
+
         <Section>
-          <Header locale={ locale } />
-
-          <Typography variant="h4" component="h2" className="py-20">
-            Premium { locale === 'en' ? 'mushrooms' : '椎茸' } at your doorstep, every month.
+          <Typography>
+            Risa and Rob
           </Typography>
-
-          <div className="flex flex-col md:flex-row md:justify-center">
-            <TextField label="Email address" variant="outlined" className="flex-grow max-w-lg mb-4 md:mr-4 md:mb-0"/>
-            <Button variant="contained" className="flex w-40 self-center md:self-auto">Start now</Button>
-          </div>
         </Section>
-        <Section backgroundColor="primary.background">
-          <FeatureSection
-            text="Organic, locally sourced, free-range mushrooms."
-            imageElement={
-              <Image
-                src={ assetUrls.happyMushroom }
-                alt="happy mushroom"
-                width={ 200 }
-                height={ 200 }
-              />
-            }
-          />
-        </Section>
-        <Section>
-          <FeatureSection
-            text="Our QA teams ensure that the mushrooms are not poisonous."
-            imageElement={
-              <iframe
-                width="560"
-                height="315"
-                src={ assetUrls.qaTeam }
-                frameBorder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowFullScreen
-              />
-            }
-            isImageOnLeft
-          />
-        </Section>
-        <Section backgroundColor="primary.background">
-          <FeatureSection
-            text="Loreming the ipsums. There should be 3 sections."
-            imageElement={
-              <Image
-                src={ assetUrls.happyMushroom }
-                alt="dancing mushroom"
-                width={ 200 }
-                height={ 200 }
-              />
-            }
-          />
-        </Section>
-      </main>
-
-      <Section>
-        <Typography>
-          Risa and Rob
-        </Typography>
-      </Section>
-    </div>
+      </div>
+    </TranslationsWrapper>
   );
 };

--- a/components/templates/HomeTemplate.tsx
+++ b/components/templates/HomeTemplate.tsx
@@ -8,82 +8,79 @@ import { assetUrls } from '../../utils/assetUrls';
 import { Section } from '../atoms/Section';
 import { Header } from '../compounds/Header';
 import { FeatureSection } from '../molecules/FeatureSection';
-import { TranslationsWrapper } from '../molecules/TranslationsWrapper';
 
 export const HomeTemplate: TopLevelTemplate = ({ locale }) => {
 
   return (
-    <TranslationsWrapper locale={ locale }>
-      <div className="h-screen min-h-screen px-2 flex flex-col items-center">
-        <Head>
-          <title>NPM</title>
-          <meta name="description" content="Mushroom subscription service" />
-          <link rel="icon" href="/favicon.ico" />
-        </Head>
+    <div className="h-screen min-h-screen px-2 flex flex-col items-center">
+      <Head>
+        <title>NPM</title>
+        <meta name="description" content="Mushroom subscription service" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
 
-        <main className="flex flex-col justify-start">
-          <Section>
-            <Header/>
-
-            <Typography variant="h4" component="h2" className="py-20">
-              Premium { locale === 'en' ? 'mushrooms' : '椎茸' } at your doorstep, every month.
-            </Typography>
-
-            <div className="flex flex-col md:flex-row md:justify-center">
-              <TextField label="Email address" variant="outlined" className="flex-grow max-w-lg mb-4 md:mr-4 md:mb-0"/>
-              <Button variant="contained" className="flex w-40 self-center md:self-auto">Start now</Button>
-            </div>
-          </Section>
-          <Section backgroundColor="primary.background">
-            <FeatureSection
-              text="Organic, locally sourced, free-range mushrooms."
-              imageElement={
-                <Image
-                  src={ assetUrls.happyMushroom }
-                  alt="happy mushroom"
-                  width={ 200 }
-                  height={ 200 }
-                />
-              }
-            />
-          </Section>
-          <Section>
-            <FeatureSection
-              text="Our QA teams ensure that the mushrooms are not poisonous."
-              imageElement={
-                <iframe
-                  width="560"
-                  height="315"
-                  src={ assetUrls.qaTeam }
-                  frameBorder="0"
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowFullScreen
-                />
-              }
-              isImageOnLeft
-            />
-          </Section>
-          <Section backgroundColor="primary.background">
-            <FeatureSection
-              text="Loreming the ipsums. There should be 3 sections."
-              imageElement={
-                <Image
-                  src={ assetUrls.happyMushroom }
-                  alt="dancing mushroom"
-                  width={ 200 }
-                  height={ 200 }
-                />
-              }
-            />
-          </Section>
-        </main>
-
+      <main className="flex flex-col justify-start">
         <Section>
-          <Typography>
-            Risa and Rob
+          <Header/>
+
+          <Typography variant="h4" component="h2" className="py-20">
+            Premium { locale === 'en' ? 'mushrooms' : '椎茸' } at your doorstep, every month.
           </Typography>
+
+          <div className="flex flex-col md:flex-row md:justify-center">
+            <TextField label="Email address" variant="outlined" className="flex-grow max-w-lg mb-4 md:mr-4 md:mb-0"/>
+            <Button variant="contained" className="flex w-40 self-center md:self-auto">Start now</Button>
+          </div>
         </Section>
-      </div>
-    </TranslationsWrapper>
+        <Section backgroundColor="primary.background">
+          <FeatureSection
+            text="Organic, locally sourced, free-range mushrooms."
+            imageElement={
+              <Image
+                src={ assetUrls.happyMushroom }
+                alt="happy mushroom"
+                width={ 200 }
+                height={ 200 }
+              />
+            }
+          />
+        </Section>
+        <Section>
+          <FeatureSection
+            text="Our QA teams ensure that the mushrooms are not poisonous."
+            imageElement={
+              <iframe
+                width="560"
+                height="315"
+                src={ assetUrls.qaTeam }
+                frameBorder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            }
+            isImageOnLeft
+          />
+        </Section>
+        <Section backgroundColor="primary.background">
+          <FeatureSection
+            text="Loreming the ipsums. There should be 3 sections."
+            imageElement={
+              <Image
+                src={ assetUrls.happyMushroom }
+                alt="dancing mushroom"
+                width={ 200 }
+                height={ 200 }
+              />
+            }
+          />
+        </Section>
+      </main>
+
+      <Section>
+        <Typography>
+          Risa and Rob
+        </Typography>
+      </Section>
+    </div>
   );
 };

--- a/components/templates/LoginTemplate.tsx
+++ b/components/templates/LoginTemplate.tsx
@@ -5,43 +5,40 @@ import 'tailwindcss/tailwind.css';
 import { Button, TextField } from '@mui/material';
 import { LocalizedLink } from '../atoms/LocalizedLink';
 import { Header } from '../compounds/Header';
-import { TranslationsWrapper } from '../molecules/TranslationsWrapper';
 
 export const LoginTemplate: TopLevelTemplate = ({ locale }) => {
   return (
-    <TranslationsWrapper locale={ locale }>
-      <div className="h-screen min-h-screen px-2 flex flex-col items-center">
-        <Head>
-          <title>Login</title>
-          <meta name="description" content="Mushroom subscription service" />
-          <link rel="icon" href="/favicon.ico" />
-        </Head>
+    <div className="h-screen min-h-screen px-2 flex flex-col items-center">
+      <Head>
+        <title>Login</title>
+        <meta name="description" content="Mushroom subscription service" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
 
-        <main className="flex flex-col pt-10 px-4 justify-start">
-          <Header/>
+      <main className="flex flex-col pt-10 px-4 justify-start">
+        <Header/>
 
-          <pre>
-            { locale === 'en' ? 'English Login' : '日本語 Baybeeee' }
-          </pre>
+        <pre>
+          { locale === 'en' ? 'English Login' : '日本語 Baybeeee' }
+        </pre>
 
-          <p className="text-3xl py-20">
-            Log in to buy even more mushrooms!
-          </p>
+        <p className="text-3xl py-20">
+          Log in to buy even more mushrooms!
+        </p>
 
-          <LocalizedLink path='/'>
-            { "Or don't :(" }
-          </LocalizedLink>
+        <LocalizedLink path='/'>
+          { "Or don't :(" }
+        </LocalizedLink>
 
-          <div className="flex flex-col md:flex-row">
-            <TextField label="Email address" variant="outlined" className="flex-grow mb-4 md:mr-4 md:mb-0"/>
-            <Button variant="contained" className="flex w-40 self-center md:self-auto">Start now</Button>
-          </div>
-        </main>
+        <div className="flex flex-col md:flex-row">
+          <TextField label="Email address" variant="outlined" className="flex-grow mb-4 md:mr-4 md:mb-0"/>
+          <Button variant="contained" className="flex w-40 self-center md:self-auto">Start now</Button>
+        </div>
+      </main>
 
-        <footer className="pt-10">
-          Risa and Rob
-        </footer>
-      </div>
-    </TranslationsWrapper>
+      <footer className="pt-10">
+        Risa and Rob
+      </footer>
+    </div>
   );
 };

--- a/components/templates/LoginTemplate.tsx
+++ b/components/templates/LoginTemplate.tsx
@@ -28,7 +28,7 @@ export const LoginTemplate: TopLevelTemplate = ({ locale }) => {
             Log in to buy even more mushrooms!
           </p>
 
-          <LocalizedLink currentLocale={ locale } path='/'>
+          <LocalizedLink path='/'>
             { "Or don't :(" }
           </LocalizedLink>
 

--- a/components/templates/LoginTemplate.tsx
+++ b/components/templates/LoginTemplate.tsx
@@ -5,40 +5,43 @@ import 'tailwindcss/tailwind.css';
 import { Button, TextField } from '@mui/material';
 import { LocalizedLink } from '../atoms/LocalizedLink';
 import { Header } from '../compounds/Header';
+import { TranslationsWrapper } from '../molecules/TranslationsWrapper';
 
 export const LoginTemplate: TopLevelTemplate = ({ locale }) => {
   return (
-    <div className="h-screen min-h-screen px-2 flex flex-col items-center">
-      <Head>
-        <title>Login</title>
-        <meta name="description" content="Mushroom subscription service" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+    <TranslationsWrapper locale={ locale }>
+      <div className="h-screen min-h-screen px-2 flex flex-col items-center">
+        <Head>
+          <title>Login</title>
+          <meta name="description" content="Mushroom subscription service" />
+          <link rel="icon" href="/favicon.ico" />
+        </Head>
 
-      <main className="flex flex-col pt-10 px-4 justify-start">
-        <Header locale={ locale } />
+        <main className="flex flex-col pt-10 px-4 justify-start">
+          <Header/>
 
-        <pre>
-          { locale === 'en' ? 'English Login' : '日本語 Baybeeee' }
-        </pre>
+          <pre>
+            { locale === 'en' ? 'English Login' : '日本語 Baybeeee' }
+          </pre>
 
-        <p className="text-3xl py-20">
-          Log in to buy even more mushrooms!
-        </p>
+          <p className="text-3xl py-20">
+            Log in to buy even more mushrooms!
+          </p>
 
-        <LocalizedLink currentLocale={ locale } path='/'>
-          { "Or don't :(" }
-        </LocalizedLink>
+          <LocalizedLink currentLocale={ locale } path='/'>
+            { "Or don't :(" }
+          </LocalizedLink>
 
-        <div className="flex flex-col md:flex-row">
-          <TextField label="Email address" variant="outlined" className="flex-grow mb-4 md:mr-4 md:mb-0"/>
-          <Button variant="contained" className="flex w-40 self-center md:self-auto">Start now</Button>
-        </div>
-      </main>
+          <div className="flex flex-col md:flex-row">
+            <TextField label="Email address" variant="outlined" className="flex-grow mb-4 md:mr-4 md:mb-0"/>
+            <Button variant="contained" className="flex w-40 self-center md:self-auto">Start now</Button>
+          </div>
+        </main>
 
-      <footer className="pt-10">
-        Risa and Rob
-      </footer>
-    </div>
+        <footer className="pt-10">
+          Risa and Rob
+        </footer>
+      </div>
+    </TranslationsWrapper>
   );
 };

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -2,10 +2,15 @@ import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import React from 'react';
 import 'tailwindcss/tailwind.css';
 import { SupportedLocale } from '../../@types';
+import { TranslationsWrapper } from '../../components/page_wrappers/TranslationsWrapper';
 import { HomeTemplate } from '../../components/templates/HomeTemplate';
 import { createNonEnglishPaths } from '../../supportedLocales';
 
-const HomePage: NextPage<{ locale: SupportedLocale }> = (props) => (<HomeTemplate { ...props } />);
+const HomePage: NextPage<{ locale: SupportedLocale }> = (props) => (
+  <TranslationsWrapper local={ props.locale }>
+    <HomeTemplate { ...props } />
+  </TranslationsWrapper>
+);
 
 export const getStaticPaths: GetStaticPaths = createNonEnglishPaths;
 

--- a/pages/[locale]/login/index.tsx
+++ b/pages/[locale]/login/index.tsx
@@ -2,10 +2,15 @@ import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import React from 'react';
 import 'tailwindcss/tailwind.css';
 import { SupportedLocale } from '../../../@types/';
+import { TranslationsWrapper } from '../../../components/page_wrappers/TranslationsWrapper';
 import { LoginTemplate } from '../../../components/templates/LoginTemplate';
 import { createNonEnglishPaths } from '../../../supportedLocales';
 
-const LoginPage: NextPage<{ locale: SupportedLocale }> = (props) => (<LoginTemplate { ...props } />);
+const LoginPage: NextPage<{ locale: SupportedLocale }> = (props) => (
+  <TranslationsWrapper locale={ props.locale }>  
+    <LoginTemplate { ...props } />
+  </TranslationsWrapper>
+);
 
 export const getStaticPaths: GetStaticPaths = createNonEnglishPaths;
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,10 +16,10 @@ const theme = createTheme({
       light: '#9a5742',
       main: '#682c1b',
       dark: '#3b0200',
-      contrastText: '#fff',
+      contrastText: '#fff'
     },
     text: { primary: '#444444' }
-  },
+  }
 });
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,14 @@
 import type { GetStaticProps, NextPage } from 'next';
 import 'tailwindcss/tailwind.css';
 import { SupportedLocale } from '../@types';
+import { TranslationsWrapper } from '../components/page_wrappers/TranslationsWrapper';
 import { HomeTemplate } from '../components/templates/HomeTemplate';
 
-const HomePage: NextPage<{ locale: SupportedLocale }> = (props) => (<HomeTemplate { ...props }/>);
+const HomePage: NextPage<{ locale: SupportedLocale }> = (props) => (
+  <TranslationsWrapper locale={ props.locale }>
+    <HomeTemplate { ...props }/>
+  </TranslationsWrapper>
+);
 
 export const getStaticProps: GetStaticProps<{ locale: SupportedLocale }> = ({ params }) => {
   return { props: { ...params, locale: 'en' } };

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -2,10 +2,15 @@ import type { GetStaticProps, NextPage } from 'next';
 import React from 'react';
 import 'tailwindcss/tailwind.css';
 import { SupportedLocale } from '../../@types';
+import { TranslationsWrapper } from '../../components/page_wrappers/TranslationsWrapper';
 import { LoginTemplate } from '../../components/templates/LoginTemplate';
 import { staticEnglishProps } from '../../supportedLocales';
 
-const LoginPage: NextPage<{ locale: SupportedLocale }> = (props) => (<LoginTemplate { ...props } />);
+const LoginPage: NextPage<{ locale: SupportedLocale }> = (props) => (
+  <TranslationsWrapper locale={ props.locale }>
+    <LoginTemplate { ...props } />
+  </TranslationsWrapper>
+);
 
 export const getStaticProps: GetStaticProps<{ locale: SupportedLocale }> = staticEnglishProps;
 


### PR DESCRIPTION
Wrap page contents in a simple context that provides locale.

Consider - 

LocalizedLink can almost certainly just use the context instead of having the locale passed in for `currentLocale` as a prop each time. Thoughts?