### PR TITLE
Wrap pages in automatic SEO and translations

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -9,4 +9,4 @@ declare module '@mui/material/styles' {
   }
 }
 
-type ListOfAppPages = 'homepage' | 'login';
+type AppPageName = 'homepage' | 'login';

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,7 +1,5 @@
 export type SupportedLocale = 'en' | 'ja';
 
-export type TopLevelTemplate = (props: {locale: SupportedLocale}) => JSX.Element;
-
 declare module '@mui/material/styles' {
   interface PaletteColor {
     background?: string
@@ -10,3 +8,5 @@ declare module '@mui/material/styles' {
     background?: string
   }
 }
+
+type ListOfAppPages = 'homepage' | 'login';

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -5,7 +5,7 @@ import { LanguageSpecificSEO } from '../utils/translations';
 import { TranslationContext } from './page_wrappers/TranslationsWrapper';
 
 type Props = {
-  pageTitle: keyof LanguageSpecificSEO
+  seoTranslationKey: keyof LanguageSpecificSEO
 };
 
 export const Seo = ({ pageTitle }: Props) => {

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -1,22 +1,24 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import Head from 'next/head';
 import { assetUrls } from '../utils/assetUrls';
+import { LanguageSpecificSEO } from '../utils/translations';
+import { TranslationContext } from './page_wrappers/TranslationsWrapper';
 
 type Props = {
-  title: string
-  description: string
+  pageTitle: keyof LanguageSpecificSEO
 };
 
-export const Seo = ({ title, description }: Props) => {
+export const Seo = ({ pageTitle }: Props) => {
+  const { seoTranslation } = useContext(TranslationContext);
   return (
     <Head>
-      <title>{ title }</title>
-      <meta name="description" content={ description }/>
+      <title>{ seoTranslation[pageTitle].title }</title>
+      <meta name="description" content={ seoTranslation[pageTitle].description }/>
       <link rel="icon" href="/favicon.ico" />
-      <meta property="og:url" content="npm.com" />
+      <meta property="og:url" content="learnkichi.com" />
       <meta property="og:type" content="website" />
-      <meta property="og:title" content={ title } />
-      <meta property="og:description" content={ description } />
+      <meta property="og:title" content={ seoTranslation[pageTitle].title } />
+      <meta property="og:description" content={ seoTranslation[pageTitle].description } />
       <meta property="og:image" content={ assetUrls.ogp } />
       <meta property="og:image:width" content="600" />
       <meta property="og:image:height" content="315" />

--- a/components/atoms/Page.tsx
+++ b/components/atoms/Page.tsx
@@ -8,7 +8,7 @@ import { Seo } from '../Seo';
 export const Page: NextPage<{ locale: SupportedLocale, seoTranslationKey: keyof LanguageSpecificSEO, children: JSX.Element }> = ({ locale, children, seoTranslationKey }) => {
   return (
     <TranslationsWrapper locale={ locale }>
-      <Seo pageTitle={ seoTranslationKey }/>
+      <Seo seoTranslationKey={ seoTranslationKey }/>
       { children }
     </TranslationsWrapper>
   );

--- a/components/atoms/Page.tsx
+++ b/components/atoms/Page.tsx
@@ -1,0 +1,15 @@
+import type { NextPage } from 'next';
+import { SupportedLocale } from '../../@types';
+import { LanguageSpecificSEO } from '../../utils/translations';
+import { TranslationsWrapper } from '../page_wrappers/TranslationsWrapper';
+import { Seo } from '../Seo';
+// each page needs seo rules, and translations wrappers.
+
+export const Page: NextPage<{ locale: SupportedLocale, seoTranslationKey: keyof LanguageSpecificSEO, children: JSX.Element }> = ({ locale, children, seoTranslationKey }) => {
+  return (
+    <TranslationsWrapper locale={ locale }>
+      <Seo pageTitle={ seoTranslationKey }/>
+      { children }
+    </TranslationsWrapper>
+  );
+};

--- a/components/page_wrappers/TranslationsWrapper.tsx
+++ b/components/page_wrappers/TranslationsWrapper.tsx
@@ -1,22 +1,22 @@
 import React, { useEffect } from 'react';
 import { SupportedLocale } from '../../@types';
-import { LanguageSpecificTranslation, translations } from '../../utils/translations';
+import { LanguageSpecificSEO, LanguageSpecificTranslation, seoTranslations, translations } from '../../utils/translations';
 
 type Props = {
   locale: SupportedLocale
-  children: JSX.Element
+  children: JSX.Element | JSX.Element[]
 };
 
 export const TranslationContext = React.createContext<{
-  locale: SupportedLocale, translation: LanguageSpecificTranslation
-}>({ locale: 'en', translation: translations.en });
+  locale: SupportedLocale, translation: LanguageSpecificTranslation, seoTranslation: LanguageSpecificSEO,
+}>({ locale: 'en', translation: translations.en, seoTranslation: seoTranslations.en });
 
 export const TranslationsWrapper = ({ locale, children }: Props) => {  
   useEffect(() => {
     document.documentElement.lang = locale;
   });
   return (
-    <TranslationContext.Provider value={ { locale, translation: translations[locale] } } >
+    <TranslationContext.Provider value={ { locale, translation: translations[locale], seoTranslation: seoTranslations[locale] } } >
       { children } 
     </TranslationContext.Provider>
   );

--- a/components/templates/home/HomeTemplate.tsx
+++ b/components/templates/home/HomeTemplate.tsx
@@ -20,7 +20,7 @@ export const HomeTemplate = () => {
 
       <Section>
         <TranslatedText>
-          { translation.footer.credits='' }
+          { translation.footer.credits }
         </TranslatedText>
       </Section>
     </div>

--- a/components/templates/home/HomeTemplate.tsx
+++ b/components/templates/home/HomeTemplate.tsx
@@ -1,23 +1,18 @@
 import React, { useContext } from 'react';
-import { TopLevelTemplate } from '../../../@types';
 import { Section } from '../../atoms/Section';
 import { TranslatedText } from '../../atoms/TranslatedText';
+import { Header } from '../../compounds/Header';
 import { TranslationContext } from '../../page_wrappers/TranslationsWrapper';
-import { Seo } from '../../Seo';
 import { FeaturesSection } from './_features_section';
 import { HeroSection } from './_hero_section';
 import { PricingSection } from './_pricing_section';
 
-export const HomeTemplate: TopLevelTemplate = () => {
+export const HomeTemplate = () => {
   const { translation } = useContext(TranslationContext);
   return (
     <div className="h-screen min-h-screen px-2 flex flex-col items-center">
-      <Seo
-        title={ translation.homepageSEO.title }
-        description={ translation.homepageSEO.description }
-      />
-
       <main className="flex flex-col justify-start">
+        <Header/>
         <HeroSection />
         <FeaturesSection />
         <PricingSection />
@@ -25,7 +20,7 @@ export const HomeTemplate: TopLevelTemplate = () => {
 
       <Section>
         <TranslatedText>
-          { translation.footer.credits }
+          { translation.footer.credits='' }
         </TranslatedText>
       </Section>
     </div>

--- a/components/templates/home/_hero_section.tsx
+++ b/components/templates/home/_hero_section.tsx
@@ -2,7 +2,6 @@ import { Button, TextField } from '@mui/material';
 import React, { useContext } from 'react';
 import { Section } from '../../atoms/Section';
 import { TranslatedText } from '../../atoms/TranslatedText';
-import { Header } from '../../compounds/Header';
 import { TranslationContext } from '../../page_wrappers/TranslationsWrapper';
 import { TextWithTypeEffect } from '../../atoms/TextWithTypeEffect';
 
@@ -10,7 +9,6 @@ export const HeroSection = () => {
   const { translation } = useContext(TranslationContext);
   return (
     <Section>
-      <Header/>
 
       <TranslatedText variant="h4" component="h2" className="py-20" >
         { translation.heroSection.tagline }

--- a/components/templates/login/LoginTemplate.tsx
+++ b/components/templates/login/LoginTemplate.tsx
@@ -1,23 +1,16 @@
 import React, { useContext } from 'react';
-import { TopLevelTemplate } from '../../../@types';
 import { Button, TextField } from '@mui/material';
 import { Header } from '../../compounds/Header';
 import { TranslationContext } from '../../page_wrappers/TranslationsWrapper';
 import { TranslatedText } from '../../atoms/TranslatedText';
-import { Seo } from '../../Seo';
 
-export const LoginTemplate: TopLevelTemplate = () => {
+export const LoginTemplate = () => {
   const { translation } = useContext(TranslationContext);
   return (
     <div className="h-screen min-h-screen px-2 flex flex-col items-center">
-      <Seo
-        title={ translation.loginSEO.title }
-        description={ translation.loginSEO.description }
-      />
 
       <main className="flex flex-col pt-10 px-4 justify-start">
         <Header/>
-
         <p className="text-3xl py-20">
           { translation.loginPage.loginTagline }
         </p>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
+/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -1,14 +1,14 @@
 import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import React from 'react';
 import { SupportedLocale } from '../../@types';
-import { TranslationsWrapper } from '../../components/page_wrappers/TranslationsWrapper';
+import { Page } from '../../components/atoms/Page';
 import { HomeTemplate } from '../../components/templates/home/HomeTemplate';
 import { createNonEnglishPaths } from '../../utils/supportedLocales';
 
-const HomePage: NextPage<{ locale: SupportedLocale }> = (props) => (
-  <TranslationsWrapper locale={ props.locale }>
-    <HomeTemplate { ...props } />
-  </TranslationsWrapper>
+const HomePage: NextPage<{ locale: SupportedLocale }> = ({ locale }) => (
+  <Page locale={ locale } seoTranslationKey='homepage'>
+    <HomeTemplate />
+  </Page>
 );
 
 export const getStaticPaths: GetStaticPaths = createNonEnglishPaths;

--- a/pages/[locale]/login/index.tsx
+++ b/pages/[locale]/login/index.tsx
@@ -1,14 +1,14 @@
 import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import React from 'react';
 import { SupportedLocale } from '../../../@types/';
-import { TranslationsWrapper } from '../../../components/page_wrappers/TranslationsWrapper';
+import { Page } from '../../../components/atoms/Page';
 import { LoginTemplate } from '../../../components/templates/login/LoginTemplate';
 import { createNonEnglishPaths } from '../../../utils/supportedLocales';
 
-const LoginPage: NextPage<{ locale: SupportedLocale }> = (props) => (
-  <TranslationsWrapper locale={ props.locale }>
-    <LoginTemplate { ...props } />
-  </TranslationsWrapper>
+const LoginPage: NextPage<{ locale: SupportedLocale }> = ({ locale }) => (
+  <Page locale={ locale } seoTranslationKey='login'>
+    <LoginTemplate/>
+  </Page>
 );
 
 export const getStaticPaths: GetStaticPaths = createNonEnglishPaths;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,12 @@
 import type { GetStaticProps, NextPage } from 'next';
 import { SupportedLocale } from '../@types';
-import { TranslationsWrapper } from '../components/page_wrappers/TranslationsWrapper';
+import { Page } from '../components/atoms/Page';
 import { HomeTemplate } from '../components/templates/home/HomeTemplate';
 
-const HomePage: NextPage<{ locale: SupportedLocale }> = (props) => (
-  <TranslationsWrapper locale={ props.locale }>
-    <HomeTemplate { ...props }/>
-  </TranslationsWrapper>
+const HomePage: NextPage<{ locale: SupportedLocale }> = ({ locale }) => (
+  <Page locale={ locale } seoTranslationKey='homepage'>
+    <HomeTemplate />
+  </Page>
 );
 
 export const getStaticProps: GetStaticProps<{ locale: SupportedLocale }> = ({ params }) => {

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,14 +1,14 @@
 import type { GetStaticProps, NextPage } from 'next';
 import React from 'react';
 import { SupportedLocale } from '../../@types';
-import { TranslationsWrapper } from '../../components/page_wrappers/TranslationsWrapper';
+import { Page } from '../../components/atoms/Page';
 import { LoginTemplate } from '../../components/templates/login/LoginTemplate';
 import { staticEnglishProps } from '../../utils/supportedLocales';
 
-const LoginPage: NextPage<{ locale: SupportedLocale }> = (props) => (
-  <TranslationsWrapper locale={ props.locale }>
-    <LoginTemplate { ...props } />
-  </TranslationsWrapper>
+const LoginPage: NextPage<{ locale: SupportedLocale }> = ({ locale }) => (
+  <Page locale={ locale } seoTranslationKey='login' >
+    <LoginTemplate />
+  </Page >
 );
 
 export const getStaticProps: GetStaticProps<{ locale: SupportedLocale }> = staticEnglishProps;

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -1,4 +1,4 @@
-import { ListOfAppPages, SupportedLocale } from '../@types';
+import { AppPageName, SupportedLocale } from '../@types';
 
 export type LanguageSpecificTranslation = {
   header: {
@@ -135,7 +135,7 @@ type SEOData = {
   description: string
 };
 
-export type LanguageSpecificSEO = Record<ListOfAppPages, SEOData>;
+export type LanguageSpecificSEO = Record<AppPageName, SEOData>;
 type MasterSEOTranslations = Record<SupportedLocale, LanguageSpecificSEO>;
 
 const enSEO: LanguageSpecificSEO = {

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -1,4 +1,4 @@
-import { SupportedLocale } from '../@types';
+import { ListOfAppPages, SupportedLocale } from '../@types';
 
 export type LanguageSpecificTranslation = {
   header: {
@@ -126,4 +126,41 @@ type MasterTranslations = Record<SupportedLocale, LanguageSpecificTranslation>;
 export const translations: MasterTranslations = {
   en: enTranslations,
   ja: jaTranslations
+};
+
+// SEO DATA ---
+
+type SEOData = {
+  title: string,
+  description: string
+};
+
+export type LanguageSpecificSEO = Record<ListOfAppPages, SEOData>;
+type MasterSEOTranslations = Record<SupportedLocale, LanguageSpecificSEO>;
+
+const enSEO: LanguageSpecificSEO = {
+  homepage: {
+    title: 'Not Poisonous Mushrooms - a mushroom subscription service',
+    description: 'NPM provides fresh mushrooms that are certified to not be poisonous every month to your doorstep!'
+  },
+  login: {
+    title: 'Login',
+    description: 'Login to your NPM account'
+  }
+};
+
+const jaSEO: LanguageSpecificSEO = {
+  homepage: {
+    title: 'Not poisonous mushrooms - きのこが毎月届くサービス',
+    description: '毒が入ってない厳選されたきのこを毎月お家にお届けします！'  
+  },
+  login: {
+    title: 'ログイン',
+    description: 'NPMアカウントにログインする'   
+  }
+};
+
+export const seoTranslations: MasterSEOTranslations = {
+  en: enSEO,
+  ja: jaSEO
 };


### PR DESCRIPTION
1) Pages now have a translation wrapper and SEO set at the top level in a single parent component. This means that the template no longer contains any strings meant for the `<head>`, and that we no longer need to set a translation provider on a per-template basis.

2) The header has been lifted out of the hero section - should probably be handled on the template level.

3) Other misc. changes, probably