### PR TITLE
Change header to have consistent buttons

### DIFF
--- a/components/compounds/Header.tsx
+++ b/components/compounds/Header.tsx
@@ -22,7 +22,7 @@ const Menu = React.memo(() => {
 
   return (
     <>
-      <div className="hidden md:flex flex-row justify-between w-128">
+      <div className="hidden md:flex flex-row justify-between w-1/4 max-w-sm min-w-fit">
         <LanguagePicker />
         <Button variant="text" color="secondary" onClick={ () => handleButtonPress('/', 'pricing') } aria-label={ translation.header.pricing }>
           <TranslatedText>{ translation.header.pricing }</TranslatedText>


### PR DESCRIPTION
This new css locks the header between two flexible, natural-looking ranges and prevents any button-smush. Not much of a change in this setup, but I noticed it looked better on Kichi and thought I should upstream it